### PR TITLE
Add simple FastAPI speed test example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
+# Speed Test Example
 
+This repository contains a minimal client–server setup for measuring latency, download and upload throughput.
+
+## Backend
+
+The backend uses [FastAPI](https://fastapi.tiangolo.com/) and exposes three endpoints:
+
+- `GET /ping` – returns a quick response for latency tests.
+- `GET /download` – streams random bytes to measure download speed.
+- `POST /upload` – reads and discards uploaded data to measure upload speed.
+
+Static files under `static/` provide a very simple HTML/JavaScript front‑end that exercises these endpoints.
+
+## Running
+
+```
+pip install fastapi uvicorn
+uvicorn main:app
+```
+
+Open <http://localhost:8000/> in your browser and click **Start Test**.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,41 @@
+from fastapi import FastAPI, Request
+from fastapi.responses import PlainTextResponse, StreamingResponse
+from fastapi.staticfiles import StaticFiles
+import os
+
+app = FastAPI()
+
+@app.get('/ping')
+async def ping() -> PlainTextResponse:
+    """Return a minimal response for latency tests."""
+    return PlainTextResponse('pong')
+
+@app.get('/download')
+async def download(size: int = 10 * 1024 * 1024) -> StreamingResponse:
+    """Stream random bytes to the client for download speed tests.
+
+    Args:
+        size: Number of bytes to stream. Defaults to 10MB.
+    """
+    chunk = 1024 * 1024  # 1MB chunks
+
+    def generate():
+        remaining = size
+        while remaining > 0:
+            data = os.urandom(min(chunk, remaining))
+            remaining -= len(data)
+            yield data
+
+    headers = {"Content-Length": str(size)}
+    return StreamingResponse(generate(), media_type='application/octet-stream', headers=headers)
+
+@app.post('/upload')
+async def upload(request: Request) -> dict:
+    """Consume uploaded data without storing it for upload speed tests."""
+    total = 0
+    async for part in request.stream():
+        total += len(part)
+    return {"received_bytes": total}
+
+# Serve static files for a simple frontend
+app.mount('/', StaticFiles(directory='static', html=True), name='static')

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Speed Test</title>
+</head>
+<body>
+  <h1>Simple Speed Test</h1>
+  <button id="start">Start Test</button>
+  <p id="ping">Ping: -</p>
+  <p id="download">Download: -</p>
+  <p id="upload">Upload: -</p>
+  <script>
+    async function testPing() {
+      const start = performance.now();
+      await fetch('/ping');
+      return performance.now() - start;
+    }
+
+    async function testDownload() {
+      const start = performance.now();
+      const response = await fetch('/download?size=' + (5 * 1024 * 1024));
+      const reader = response.body.getReader();
+      let received = 0;
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        received += value.length;
+      }
+      const duration = (performance.now() - start) / 1000;
+      return (received * 8 / duration) / 1_000_000; // Mbps
+    }
+
+    async function testUpload() {
+      const size = 5 * 1024 * 1024;
+      const data = new Uint8Array(size);
+      crypto.getRandomValues(data);
+      const start = performance.now();
+      await fetch('/upload', { method: 'POST', body: data });
+      const duration = (performance.now() - start) / 1000;
+      return (size * 8 / duration) / 1_000_000; // Mbps
+    }
+
+    document.getElementById('start').addEventListener('click', async () => {
+      document.getElementById('ping').textContent = 'Ping: testing...';
+      document.getElementById('download').textContent = 'Download: testing...';
+      document.getElementById('upload').textContent = 'Upload: testing...';
+
+      const ping = await testPing();
+      document.getElementById('ping').textContent = `Ping: ${ping.toFixed(2)} ms`;
+
+      const download = await testDownload();
+      document.getElementById('download').textContent = `Download: ${download.toFixed(2)} Mbps`;
+
+      const upload = await testUpload();
+      document.getElementById('upload').textContent = `Upload: ${upload.toFixed(2)} Mbps`;
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement FastAPI backend with `/ping`, `/download`, and `/upload` endpoints
- serve simple HTML/JS frontend to run latency, download, and upload tests
- document setup and usage in README

## Testing
- `python -m py_compile main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ac17debce88333adedc6697f67d6f1