### PR TITLE
Enforce HTTPS and add certificate configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
+# Simple Flask-based speed test service
+
+This application provides basic endpoints for checking network latency,
+download, and upload speeds. By default the server enforces HTTPS: any HTTP
+request is redirected to the HTTPS version of the URL.
+
+## Running
+
+1. **Install dependencies** (Flask is the only requirement):
+
+   ```bash
+   pip install flask
+   ```
+
+2. **Provide certificate and key files** by exporting their paths. When both
+   variables are defined the application automatically listens on port `443` and
+   serves requests via HTTPS:
+
+   ```bash
+   export CERT_FILE=/path/to/cert.pem
+   export KEY_FILE=/path/to/key.pem
+   python app.py
+   ```
+
+   If the variables are not set the app falls back to HTTP on port `80`.
+
+All HTTP requests are redirected to HTTPS, allowing the service to respond only
+over secure connections.
 

--- a/app.py
+++ b/app.py
@@ -1,11 +1,23 @@
 # app.py
 # Import necessary libraries from Flask and standard Python libraries
-from flask import Flask, render_template, Response, request
+from flask import Flask, render_template, Response, request, redirect
 import time
 import os
 
 # Initialize the Flask application
 app = Flask(__name__)
+
+
+@app.before_request
+def enforce_https():
+    """Redirect incoming requests to HTTPS if they arrive via HTTP."""
+    # When running behind a proxy (e.g. in production), the X-Forwarded-Proto
+    # header is commonly used to signal the original scheme. Fall back to
+    # Flask's ``request.is_secure`` for direct requests.
+    proto = request.headers.get("X-Forwarded-Proto", "http")
+    if proto != "https" and not request.is_secure:
+        url = request.url.replace("http://", "https://", 1)
+        return redirect(url, code=301)
 
 # Define the main route for the website
 @app.route('/')
@@ -69,4 +81,8 @@ def upload():
 if __name__ == '__main__':
     # Running the app on 0.0.0.0 makes it accessible from other devices on the same network.
     # Debug mode is turned off for a more production-like environment.
-    app.run(host='0.0.0.0', port=80, debug=False)
+    cert_file = os.environ.get('CERT_FILE')
+    key_file = os.environ.get('KEY_FILE')
+    ssl_context = (cert_file, key_file) if cert_file and key_file else None
+    port = 443 if ssl_context else 80
+    app.run(host='0.0.0.0', port=port, debug=False, ssl_context=ssl_context)


### PR DESCRIPTION
## Summary
- redirect all HTTP requests to HTTPS
- allow configuring SSL certificate and key via `CERT_FILE` and `KEY_FILE`
- update README with instructions and HTTPS behavior

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68ac3b6ffffc8333b5c9d438b3e04b20