### PR TITLE
Enforce HTTPS and support custom certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
+## Speedtest Server
+
+This Flask application provides simple endpoints for network speed testing.
+
+### HTTPS Only
+
+The server responds exclusively over HTTPS. Any HTTP request is redirected to HTTPS.
+
+To provide your own certificate, set the following environment variables before running the app:
+
+```
+export CERT_FILE=/path/to/cert.pem
+export KEY_FILE=/path/to/key.pem
+```
+
+If these variables are not supplied, a temporary self‑signed certificate is generated.
+
+Run the application with:
+
+```
+python app.py
+```
+
+The HTTPS server listens on port **443**, while HTTP port **80** is used only for redirects.
 


### PR DESCRIPTION
## Summary
- redirect all HTTP traffic to HTTPS
- add optional CERT_FILE and KEY_FILE env vars for SSL context
- document HTTPS setup and certificate configuration

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68ac3b6ffffc8333b5c9d438b3e04b20