### PR TITLE
Enforce HTTPS and add SSL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
+# Speedtest
 
+Simple Flask application for measuring network speed.
+
+## HTTPS
+
+The server now enforces HTTPS and redirects HTTP requests to HTTPS.
+Custom certificate and key files can be specified via the environment
+variables `SSL_CERT_FILE` and `SSL_KEY_FILE`. If not provided, a temporary
+certificate is generated automatically.


### PR DESCRIPTION
## Summary
- Redirect HTTP requests to HTTPS
- Allow custom certificate and key via `SSL_CERT_FILE` and `SSL_KEY_FILE` environment variables

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68ac3b6ffffc8333b5c9d438b3e04b20