### PR TITLE
Enforce HTTPS and allow configurable TLS certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
+## Speedtest Server
 
+This repository hosts a small Flask application used for network speed
+testing. The server is configured to respond exclusively over HTTPS and
+automatically redirects any HTTP requests to HTTPS.
+
+### TLS Configuration
+
+Provide paths to your TLS certificate and key via environment variables
+before starting the application:
+
+```
+export SSL_CERT_FILE=/path/to/cert.pem
+export SSL_KEY_FILE=/path/to/key.pem
+python app.py
+```
+
+If no certificate/key is supplied the server falls back to a temporary
+self‑signed certificate (suitable for local testing only).


### PR DESCRIPTION
## Summary
- Redirect all HTTP traffic to HTTPS and serve content only over TLS
- Allow SSL certificate and key paths to be configured via `SSL_CERT_FILE` and `SSL_KEY_FILE`
- Document HTTPS behavior and TLS configuration in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68ac3b6ffffc8333b5c9d438b3e04b20