### PR TITLE
Configure Flask app for HTTPS via .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+DOMAINS=example.com,www.example.com
+SSL_CERT_FILE=/etc/ssl/certs/example.com.crt
+SSL_KEY_FILE=/etc/ssl/private/example.com.key
+HOST=0.0.0.0
+PORT=443

--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
 # Speedtest
 
 Simple Flask application for measuring network speed.
+
+## Configuration
+
+Create a `.env` file in the project root to configure HTTPS and allowed domains:
+
+```
+DOMAINS=example.com,www.example.com
+SSL_CERT_FILE=/etc/ssl/certs/example.com.crt
+SSL_KEY_FILE=/etc/ssl/private/example.com.key
+HOST=0.0.0.0
+PORT=443
+```
+
+Run the application with:
+
+```
+python app.py
+```
+
+The server will start on HTTPS port `443` using the provided certificate files.


### PR DESCRIPTION
## Summary
- load environment variables from `.env` and enforce allowed domains
- run Flask app with SSL certificates on port 443
- document HTTPS configuration and add sample `.env`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68ac43a47de88333b370d1737a20753e