### PR TITLE
Translate speed test interface to Persian

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fa" dir="rtl">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Python Speed Test</title>
+    <title>تست سرعت اینترنت پایتون</title>
     <!-- Tailwind CSS for styling -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Google Fonts for a modern look -->
@@ -38,8 +38,8 @@
 
     <div class="w-full max-w-4xl mx-auto">
         <header class="text-center mb-8">
-            <h1 class="text-4xl font-bold text-cyan-400">Python Internet Speed Test</h1>
-            <p class="text-gray-400 mt-2">Powered by Flask & JavaScript</p>
+            <h1 class="text-4xl font-bold text-cyan-400">تست سرعت اینترنت پایتون</h1>
+            <p class="text-gray-400 mt-2">ساخته شده با Flask و JavaScript</p>
         </header>
 
         <main class="flex flex-col items-center">
@@ -63,13 +63,13 @@
                 <!-- Speed display text in the center of the gauge -->
                 <div id="speed-display" class="absolute bottom-0 left-1/2 -translate-x-1/2 text-center">
                     <span id="speed-value" class="text-5xl font-bold">0.00</span>
-                    <span id="speed-unit" class="text-gray-400 block">Mbps</span>
+                    <span id="speed-unit" class="text-gray-400 block">مگابیت بر ثانیه</span>
                 </div>
             </div>
 
             <!-- Start button -->
             <button id="start-btn" class="relative bg-cyan-500 hover:bg-cyan-600 text-gray-900 font-bold rounded-full w-32 h-32 flex items-center justify-center text-3xl shadow-lg transition-all duration-300 transform hover:scale-105 focus:outline-none focus:ring-4 focus:ring-cyan-300 focus:ring-opacity-50 disabled:bg-gray-600 disabled:cursor-not-allowed animate-pulse-slow">
-                Go
+                شروع
             </button>
             <div id="status-text" class="mt-4 text-lg text-gray-400 h-6"></div>
         </main>
@@ -77,16 +77,16 @@
         <!-- Results section -->
         <footer class="mt-10 grid grid-cols-1 sm:grid-cols-3 gap-4 text-center w-full max-w-2xl mx-auto">
             <div class="bg-gray-800 p-4 rounded-lg">
-                <h2 class="text-sm font-semibold text-cyan-400">PING</h2>
-                <p id="ping-result" class="text-2xl font-bold">- ms</p>
+                <h2 class="text-sm font-semibold text-cyan-400">پینگ</h2>
+                <p id="ping-result" class="text-2xl font-bold">- میلی‌ثانیه</p>
             </div>
             <div class="bg-gray-800 p-4 rounded-lg">
-                <h2 class="text-sm font-semibold text-cyan-400">DOWNLOAD</h2>
-                <p id="download-result" class="text-2xl font-bold">- Mbps</p>
+                <h2 class="text-sm font-semibold text-cyan-400">دانلود</h2>
+                <p id="download-result" class="text-2xl font-bold">- مگابیت بر ثانیه</p>
             </div>
             <div class="bg-gray-800 p-4 rounded-lg">
-                <h2 class="text-sm font-semibold text-cyan-400">UPLOAD</h2>
-                <p id="upload-result" class="text-2xl font-bold">- Mbps</p>
+                <h2 class="text-sm font-semibold text-cyan-400">آپلود</h2>
+                <p id="upload-result" class="text-2xl font-bold">- مگابیت بر ثانیه</p>
             </div>
         </footer>
     </div>
@@ -133,11 +133,11 @@
                 uploadResult.innerHTML = `${uploadSpeed.toFixed(2)} <span class="text-base text-gray-400">Mbps</span>`;
 
             } catch (error) {
-                statusText.textContent = "An error occurred during the test.";
+            statusText.textContent = "خطایی در هنگام تست رخ داد.";
                 console.error(error);
             } finally {
                 // Re-enable button and finalize UI
-                statusText.textContent = "Test Complete!";
+            statusText.textContent = "تست کامل شد!";
                 startBtn.disabled = false;
                 startBtn.classList.add('animate-pulse-slow');
                 updateGauge(0); // Reset gauge to zero
@@ -162,7 +162,7 @@
          * @returns {Promise<number>} The average ping in milliseconds.
          */
         async function testPing() {
-            statusText.textContent = 'Testing Ping...';
+            statusText.textContent = 'در حال آزمایش پینگ...';
             let totalTime = 0;
             for (let i = 0; i < PING_COUNT; i++) {
                 const startTime = performance.now();
@@ -179,7 +179,7 @@
          * @returns {Promise<number>} The average download speed in Mbps.
          */
         function testDownload() {
-            statusText.textContent = 'Testing Download Speed...';
+            statusText.textContent = 'در حال آزمایش سرعت دانلود...';
             return new Promise(async (resolve, reject) => {
                 let totalBytes = 0;
                 const startTime = performance.now();
@@ -245,7 +245,7 @@
          * @returns {Promise<number>} The average upload speed in Mbps.
          */
         function testUpload() {
-            statusText.textContent = 'Testing Upload Speed...';
+            statusText.textContent = 'در حال آزمایش سرعت آپلود...';
             return new Promise(async (resolve, reject) => {
                 try {
                     // Generate random data to upload
@@ -270,11 +270,11 @@
                             const finalSpeedMbps = (UPLOAD_DATA_SIZE * 8) / (finalElapsedTime * 1000 * 1000);
                             resolve(finalSpeedMbps);
                         } else {
-                            reject(new Error(`Server responded with status: ${xhr.status}`));
+                            reject(new Error(`سرور با وضعیت ${xhr.status} پاسخ داد`));
                         }
                     };
                     
-                    xhr.onerror = () => reject(new Error('Upload failed'));
+                    xhr.onerror = () => reject(new Error('آپلود ناموفق بود'));
                     
                     xhr.send(data);
 


### PR DESCRIPTION
## Summary
- Localized the HTML template to Persian, including page title, headers, button text, and measurement labels.
- Added Farsi status and error messages for ping, download, and upload tests.

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68ac49525c7c8333ac0b779962c55613