### PR TITLE
Implement ICMP-based ping measurement

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,14 @@ python app.py
 ```
 
 The server will start on HTTPS port `443` using the provided certificate files.
+
+## Ping Test
+
+Latency measurements now use ICMP echo requests via the [`ping3`](https://pypi.org/project/ping3/) library. Make sure the
+environment has the package installed:
+
+```
+pip install ping3
+```
+
+Running ICMP pings may require administrative privileges depending on the operating system.

--- a/templates/index.html
+++ b/templates/index.html
@@ -165,11 +165,11 @@
             statusText.textContent = 'در حال آزمایش پینگ...';
             let totalTime = 0;
             for (let i = 0; i < PING_COUNT; i++) {
-                const startTime = performance.now();
-                // Use a cache-busting query parameter to ensure fresh requests
-                await fetch(`/ping?t=${new Date().getTime()}`);
-                const endTime = performance.now();
-                totalTime += (endTime - startTime);
+                const response = await fetch(`/ping?t=${Date.now()}`);
+                const value = parseFloat(await response.text());
+                if (!isNaN(value)) {
+                    totalTime += value;
+                }
             }
             return totalTime / PING_COUNT;
         }


### PR DESCRIPTION
## Summary
- replace HTTP-based ping with ICMP echo using `ping3`
- update front-end ping logic to use server-provided latency values
- document new `ping3` dependency for ICMP pings

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68ac4d72b47c8333bfcc6f25508d8142