### PR TITLE
Measure ping over TCP

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,6 +48,7 @@ def ping():
     response.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
     response.headers['Pragma'] = 'no-cache'
     response.headers['Expires'] = '0'
+    response.headers['Connection'] = 'close'
     return response
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -167,7 +167,7 @@
             for (let i = 0; i < PING_COUNT; i++) {
                 const startTime = performance.now();
                 // Use a cache-busting query parameter to ensure fresh requests
-                await fetch(`/ping?t=${new Date().getTime()}`);
+                await fetch(`/ping?t=${Date.now()}`, { cache: 'no-store' });
                 const endTime = performance.now();
                 totalTime += (endTime - startTime);
             }


### PR DESCRIPTION
## Summary
- add Connection: close header so each ping uses a fresh TCP connection
- instruct client to disable cache when pinging

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68ac5378d8cc83338ff44974a62307be