### PR TITLE
Ensure ping measurements use TCP connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Simple Flask application for measuring network speed.
 
+The `/ping` endpoint forces the TCP connection to close on every request so
+that latency is calculated over a fresh TCP handshake similar to speedtest.net.
+
 ## Configuration
 
 Create a `.env` file in the project root to configure HTTPS and allowed domains:

--- a/app.py
+++ b/app.py
@@ -48,6 +48,7 @@ def ping():
     response.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
     response.headers['Pragma'] = 'no-cache'
     response.headers['Expires'] = '0'
+    response.headers['Connection'] = 'close'
     return response
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -167,7 +167,7 @@
             for (let i = 0; i < PING_COUNT; i++) {
                 const startTime = performance.now();
                 // Use a cache-busting query parameter to ensure fresh requests
-                await fetch(`/ping?t=${new Date().getTime()}`);
+                await fetch(`/ping?t=${new Date().getTime()}`, { cache: 'no-store' });
                 const endTime = performance.now();
                 totalTime += (endTime - startTime);
             }


### PR DESCRIPTION
## Summary
- Force `/ping` to close connections so each request measures TCP handshake latency
- Prevent caching of ping requests in client script
- Document TCP-based ping behavior in README

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ac5378d8cc83338ff44974a62307be