### PR TITLE
Enforce new TCP connection for ping test

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,6 +48,10 @@ def ping():
     response.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
     response.headers['Pragma'] = 'no-cache'
     response.headers['Expires'] = '0'
+    # Close the connection after each response so the client must establish a new
+    # TCP connection for every ping request. This mimics the behaviour of
+    # services like speedtest.net that measure latency based on TCP handshakes.
+    response.headers['Connection'] = 'close'
     return response
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -166,8 +166,10 @@
             let totalTime = 0;
             for (let i = 0; i < PING_COUNT; i++) {
                 const startTime = performance.now();
-                // Use a cache-busting query parameter to ensure fresh requests
-                await fetch(`/ping?t=${new Date().getTime()}`);
+                // Use a cache-busting query parameter and disable caching so
+                // each request opens a new TCP connection to the server. This
+                // approximates the latency measurement used by speedtest.net.
+                await fetch(`/ping?t=${Date.now()}`, { cache: 'no-store' });
                 const endTime = performance.now();
                 totalTime += (endTime - startTime);
             }


### PR DESCRIPTION
## Summary
- Close connection on `/ping` so each ping opens a fresh TCP connection
- Disable caching on ping requests in frontend to mirror speedtest-style latency measurement

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68ac5378d8cc83338ff44974a62307be