### PR TITLE
feat: improve ping test calculation

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -75,10 +75,14 @@
         </main>
 
         <!-- Results section -->
-        <footer class="mt-10 grid grid-cols-1 sm:grid-cols-3 gap-4 text-center w-full max-w-2xl mx-auto">
+        <footer class="mt-10 grid grid-cols-1 sm:grid-cols-4 gap-4 text-center w-full max-w-2xl mx-auto">
             <div class="bg-gray-800 p-4 rounded-lg">
                 <h2 class="text-sm font-semibold text-cyan-400">پینگ</h2>
-                <p id="ping-result" class="text-2xl font-bold">- میلی‌ثانیه</p>
+                <p id="ping-result" class="text-2xl font-bold">- <span class="text-base text-gray-400">ms</span></p>
+            </div>
+            <div class="bg-gray-800 p-4 rounded-lg">
+                <h2 class="text-sm font-semibold text-cyan-400">جیتر</h2>
+                <p id="jitter-result" class="text-2xl font-bold">- <span class="text-base text-gray-400">ms</span></p>
             </div>
             <div class="bg-gray-800 p-4 rounded-lg">
                 <h2 class="text-sm font-semibold text-cyan-400">دانلود</h2>
@@ -96,6 +100,7 @@
         const startBtn = document.getElementById('start-btn');
         const statusText = document.getElementById('status-text');
         const pingResult = document.getElementById('ping-result');
+        const jitterResult = document.getElementById('jitter-result');
         const downloadResult = document.getElementById('download-result');
         const uploadResult = document.getElementById('upload-result');
         const speedValue = document.getElementById('speed-value');
@@ -104,7 +109,7 @@
         const progressArc = document.getElementById('progress-arc');
 
         // Configuration for the tests
-        const PING_COUNT = 5;
+        const PING_COUNT = 10;
         const DOWNLOAD_TEST_DURATION = 10000; // 10 seconds
         const UPLOAD_TEST_DURATION = 8000; // 8 seconds
         const UPLOAD_DATA_SIZE = 20 * 1024 * 1024; // 20 MB
@@ -123,8 +128,9 @@
 
             try {
                 // Run tests sequentially
-                const ping = await testPing();
+                const { ping, jitter } = await testPing();
                 pingResult.innerHTML = `${ping.toFixed(2)} <span class="text-base text-gray-400">ms</span>`;
+                jitterResult.innerHTML = `${jitter.toFixed(2)} <span class="text-base text-gray-400">ms</span>`;
 
                 const downloadSpeed = await testDownload();
                 downloadResult.innerHTML = `${downloadSpeed.toFixed(2)} <span class="text-base text-gray-400">Mbps</span>`;
@@ -150,6 +156,7 @@
         function resetResults() {
             statusText.textContent = '';
             pingResult.innerHTML = `- <span class="text-base text-gray-400">ms</span>`;
+            jitterResult.innerHTML = `- <span class="text-base text-gray-400">ms</span>`;
             downloadResult.innerHTML = `- <span class="text-base text-gray-400">Mbps</span>`;
             uploadResult.innerHTML = `- <span class="text-base text-gray-400">Mbps</span>`;
             updateGauge(0);
@@ -159,19 +166,24 @@
 
         /**
          * Measures latency by pinging the server.
-         * @returns {Promise<number>} The average ping in milliseconds.
+         * @returns {Promise<{ping: number, jitter: number}>} Ping and jitter in milliseconds.
          */
         async function testPing() {
             statusText.textContent = 'در حال آزمایش پینگ...';
-            let totalTime = 0;
+            const samples = [];
             for (let i = 0; i < PING_COUNT; i++) {
                 const startTime = performance.now();
-                // Use a cache-busting query parameter to ensure fresh requests
-                await fetch(`/ping?t=${new Date().getTime()}`);
+                await fetch(`/ping?t=${Date.now()}`, { cache: 'no-store' });
                 const endTime = performance.now();
-                totalTime += (endTime - startTime);
+                samples.push(endTime - startTime);
             }
-            return totalTime / PING_COUNT;
+            const ping = Math.min(...samples);
+            let jitter = 0;
+            for (let i = 1; i < samples.length; i++) {
+                jitter += Math.abs(samples[i] - samples[i - 1]);
+            }
+            jitter = jitter / (samples.length - 1);
+            return { ping, jitter };
         }
 
         /**


### PR DESCRIPTION
## Summary
- add jitter result section alongside ping
- calculate ping using best round-trip and report jitter

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ac53833a4c833392e8f96df954de6e