### PR TITLE
Add TCP-based ping endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -51,6 +51,17 @@ def ping():
     return response
 
 
+@app.route('/tcp-ping')
+def tcp_ping():
+    """A TCP-based ping endpoint that forces a new connection for each request."""
+    response = Response("pong")
+    response.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
+    response.headers['Pragma'] = 'no-cache'
+    response.headers['Expires'] = '0'
+    response.headers['Connection'] = 'close'
+    return response
+
+
 @app.before_request
 def restrict_host():
     """Restrict requests to configured domains if provided."""

--- a/templates/index.html
+++ b/templates/index.html
@@ -162,7 +162,7 @@
         }
 
         /**
-         * Measures latency by pinging the server similarly to speedtest.net.
+         * Measures latency using fresh TCP connections to the server.
          * Returns the best ping and average jitter.
          * @returns {Promise<{ping:number, jitter:number}>}
          */
@@ -170,7 +170,7 @@
             statusText.textContent = 'در حال آزمایش پینگ...';
 
             // Warm-up request to avoid initial DNS or connection delays
-            await fetch(`/ping?t=${Date.now()}`);
+            await fetch(`/tcp-ping?t=${Date.now()}`, { cache: 'no-store' });
 
             const times = [];
             let previous = null;
@@ -178,7 +178,7 @@
 
             for (let i = 0; i < PING_COUNT; i++) {
                 const startTime = performance.now();
-                await fetch(`/ping?t=${Date.now()}&i=${i}`);
+                await fetch(`/tcp-ping?t=${Date.now()}&i=${i}`, { cache: 'no-store' });
                 const duration = performance.now() - startTime;
                 times.push(duration);
                 if (previous !== null) {


### PR DESCRIPTION
## Summary
- add `/tcp-ping` endpoint to measure latency via new TCP connections
- update client to use new endpoint with explicit cache bypass
## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68ac586024bc8333926d49e7e1972e2c