### PR TITLE
Display ping samples like ICMP

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -80,6 +80,7 @@
                 <h2 class="text-sm font-semibold text-cyan-400">پینگ</h2>
                 <p id="ping-result" class="text-2xl font-bold">- <span class="text-base text-gray-400">ms</span></p>
                 <p id="jitter-result" class="text-sm text-gray-400">جیتر: - <span class="text-xs">ms</span></p>
+                <div id="ping-details" class="text-xs text-gray-400 mt-2 text-left"></div>
             </div>
             <div class="bg-gray-800 p-4 rounded-lg">
                 <h2 class="text-sm font-semibold text-cyan-400">دانلود</h2>
@@ -98,6 +99,7 @@
         const statusText = document.getElementById('status-text');
         const pingResult = document.getElementById('ping-result');
         const jitterResult = document.getElementById('jitter-result');
+        const pingDetails = document.getElementById('ping-details');
         const downloadResult = document.getElementById('download-result');
         const uploadResult = document.getElementById('upload-result');
         const speedValue = document.getElementById('speed-value');
@@ -154,6 +156,7 @@
             statusText.textContent = '';
             pingResult.innerHTML = `- <span class="text-base text-gray-400">ms</span>`;
             jitterResult.innerHTML = `جیتر: - <span class="text-xs text-gray-400">ms</span>`;
+            pingDetails.innerHTML = '';
             downloadResult.innerHTML = `- <span class="text-base text-gray-400">Mbps</span>`;
             uploadResult.innerHTML = `- <span class="text-base text-gray-400">Mbps</span>`;
             updateGauge(0);
@@ -181,6 +184,7 @@
                 await fetch(`/ping?t=${Date.now()}&i=${i}`);
                 const duration = performance.now() - startTime;
                 times.push(duration);
+                pingDetails.innerHTML += `پینگ ${i + 1}: ${duration.toFixed(2)} ms<br>`;
                 if (previous !== null) {
                     jitterSum += Math.abs(duration - previous);
                 }


### PR DESCRIPTION
## Summary
- show per-request ping measurements similar to ICMP ping output

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68ac5b17b028833386424e85018724b7