### PR TITLE
Use ICMP ping for latency test

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Simple Flask application for measuring network speed.
 
+The application now performs latency tests using ICMP ping from the server to the client instead of measuring HTTP request times.
+
 ## Configuration
 
 Create a `.env` file in the project root to configure HTTPS and allowed domains:

--- a/templates/index.html
+++ b/templates/index.html
@@ -172,17 +172,14 @@
         async function testPing() {
             statusText.textContent = 'در حال آزمایش پینگ...';
 
-            // Warm-up request to avoid initial DNS or connection delays
-            await fetch(`/ping?t=${Date.now()}`);
-
             const times = [];
             let previous = null;
             let jitterSum = 0;
 
             for (let i = 0; i < PING_COUNT; i++) {
-                const startTime = performance.now();
-                await fetch(`/ping?t=${Date.now()}&i=${i}`);
-                const duration = performance.now() - startTime;
+                const response = await fetch(`/ping?t=${Date.now()}&i=${i}`);
+                const data = await response.json();
+                const duration = data.ping;
                 times.push(duration);
                 pingDetails.innerHTML += `پینگ ${i + 1}: ${duration.toFixed(2)} ms<br>`;
                 if (previous !== null) {


### PR DESCRIPTION
## Summary
- Replace HTTP-based latency measurement with server-side ICMP ping.
- Adjust front-end to consume ping results returned as JSON.
- Document ICMP ping usage in README.

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_68ac5c52a9f483338374c7937ebed2e3